### PR TITLE
Call purge after uninstall

### DIFF
--- a/lib/autoparts/package.rb
+++ b/lib/autoparts/package.rb
@@ -313,6 +313,7 @@ module Autoparts
       parent = prefix_path.parent
       parent.rmtree if parent.children.empty?
       post_uninstall
+      purge
 
       puts "=> Uninstalled #{name} #{version}\n"
     end


### PR DESCRIPTION
I guess `purge` needs to be called after a package is uninstalled? 

Or we can remove it and do the cleanup in `post_uninstall` itself? 
