### PR TITLE
Add Tig

### DIFF
--- a/lib/autoparts/packages/tig.rb
+++ b/lib/autoparts/packages/tig.rb
@@ -1,0 +1,29 @@
+module Autoparts
+  module Packages
+    class Tig < Package
+      name 'tig'
+      version '1.2.1'
+      description 'Tig: An ncurses-based text-mode interface for git.'
+      source_url 'http://jonas.nitro.dk/tig/releases/tig-1.2.1.tar.gz'
+      source_sha1 '5755bae7342debf94ef33973e0eaff6207e623dc'
+      source_filetype 'tar.gz'
+
+      def compile
+        Dir.chdir(name_with_version) do
+          args = [
+            "--prefix=#{prefix_path}",
+            "--sysconfdir=#{Path.etc}"
+          ]
+          execute './configure', *args
+        end
+      end
+
+      def install
+        Dir.chdir(name_with_version) do
+          bin_path.mkpath
+          execute 'make install'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Somebody ("adam price") asked for `tig` and `tree` in the guest chatroom.

I'm guessing `tree` should be an `apt` thing for the base box images if you wanted to add that.

(This is homebrew for Linux, right?)
