### PR TITLE
Don't clobber a prexisting LIBRARY_PATH on init

### DIFF
--- a/lib/autoparts/commands/init.rb
+++ b/lib/autoparts/commands/init.rb
@@ -26,13 +26,13 @@ module Autoparts
         puts <<-STR.unindent
           export AUTOPARTS_ROOT="#{Path.root}"
           export PATH="$AUTOPARTS_ROOT/bin:$AUTOPARTS_ROOT/sbin:$PATH"
-          export LD_LIBRARY_PATH="$AUTOPARTS_ROOT/lib:/usr/local/lib:/usr/lib"
-          export LIBRARY_PATH="$AUTOPARTS_ROOT/lib:/usr/local/lib:/usr/lib"
+          export LD_LIBRARY_PATH="$AUTOPARTS_ROOT/lib:/usr/local/lib:/usr/lib:$LD_LIBRARY_PATH"
+          export LIBRARY_PATH="$AUTOPARTS_ROOT/lib:/usr/local/lib:/usr/lib:$LIBRARY_PATH"
           export DYLD_FALLBACK_LIBRARY_PATH="$AUTOPARTS_ROOT/lib"
           export C_INCLUDE_PATH="$AUTOPARTS_ROOT/include"
           export CPLUS_INCLUDE_PATH="$AUTOPARTS_ROOT/include"
           export OBJC_INCLUDE_PATH="$AUTOPARTS_ROOT/include"
-          export MAN_PATH="$AUTOPARTS_ROOT/share/man:/usr/local/share/man:/usr/share/man"
+          export MAN_PATH="$AUTOPARTS_ROOT/share/man:/usr/local/share/man:/usr/share/man:$MAN_PATH"
         STR
       end
 


### PR DESCRIPTION
LD_LIBRARY_PATH and LIBRARY_PATH shouldn't get blown away during `parts init`,
instead prepend the parts related paths.  There is a chance that /usr/local/lib
and similar would get duplicated, but no harm in that case.
