### PR TITLE
Add parts info command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ tmp/
 *.gem
 *.rbc
 .bundle
+vendor/bundle
 .config
 .yardoc
 Gemfile.lock

--- a/bin/parts
+++ b/bin/parts
@@ -18,6 +18,7 @@ cli = Autoparts::CLIParser.new(ARGV)
 commands = {
   'help'      => Autoparts::Commands::Help,
   'init'      => Autoparts::Commands::Init,
+  'info'      => Autoparts::Commands::Info,
   'install'   => Autoparts::Commands::Install,
   'list'      => Autoparts::Commands::List,
   'purge'     => Autoparts::Commands::Purge,

--- a/lib/autoparts.rb
+++ b/lib/autoparts.rb
@@ -18,6 +18,7 @@ require 'autoparts/commands/start'
 require 'autoparts/commands/stop'
 require 'autoparts/commands/restart'
 require 'autoparts/commands/status'
+require 'autoparts/commands/info'
 require 'autoparts/commands/update'
 require 'autoparts/commands/upload'
 

--- a/lib/autoparts/commands/help.rb
+++ b/lib/autoparts/commands/help.rb
@@ -23,6 +23,7 @@ module Autoparts
               parts stop PACKAGE...      # Stop one or many services provided by packages
               parts restart PACKAGE...   # Restart one or many services provided by packages
               parts status [PACKAGE...]  # Show status of one or many services provided by packages
+              parts info PACKAGE...      # Prints dependencies and tips of one or many packages
               parts update               # Update Autoparts
           EOS
         end

--- a/lib/autoparts/commands/info.rb
+++ b/lib/autoparts/commands/info.rb
@@ -1,0 +1,28 @@
+module Autoparts
+  module Commands
+    class Info
+      def initialize(args, options)
+        if args.empty?
+          abort <<-EOS.unindent
+            Usage: parts info PACKAGE... [OPTION]
+            Example: parts info postgresql
+          EOS
+        end
+        begin
+          args.each do |package_name|
+            package = Package.factory(package_name)
+            puts "#{package.name} (#{package.version})"
+            puts package.description
+            puts "=> Dependencies: #{package.dependencies}" if package.dependencies.count > 0
+            if package.tips
+              puts '=> Tips:'
+              puts package.tips
+            end
+          end
+        rescue => e
+          abort "parts: ERROR: #{e}\nAborting!"
+        end
+      end
+    end
+  end
+end

--- a/lib/autoparts/dependency.rb
+++ b/lib/autoparts/dependency.rb
@@ -48,5 +48,9 @@ module Autoparts
       end
       tree
     end
+
+    def to_s
+      install_order.join(', ').to_s
+    end
   end
 end

--- a/spec/dependency_spec.rb
+++ b/spec/dependency_spec.rb
@@ -19,6 +19,22 @@ describe Autoparts::Dependency do
     end
   end
 
+  describe '#count' do
+    it 'returns the number of children' do
+      apache2 = described_class.new Pkg.new('apache2')
+      apr_util = described_class.new Pkg.new('apr-util')
+      apr = described_class.new Pkg.new('apr')
+
+      apache2.add_child apr_util
+      apache2.add_child apr
+      apr_util.add_child apr
+
+      expect(apache2.count).to eql(2)
+      expect(apr_util.count).to eql(1)
+      expect(apr.count).to eql(0)
+    end
+  end
+
   describe '#add_child' do
     it 'adds children to the dependency' do
       d1 = described_class.new Pkg.new("mysql")
@@ -49,6 +65,24 @@ describe Autoparts::Dependency do
       expect(pkg3.install_order).to eql(["apr", "apr-util"])
       expect(pkg4.install_order).to eql(["apr"])
       expect(pkg5.install_order).to eql([])
+    end
+  end
+
+  describe '#to_s' do
+    it 'returns a comma-separated string containing the install order of the dependency' do
+      php5 = described_class.new Pkg.new('php5')
+      apache2 = described_class.new Pkg.new('apache2')
+      apr_util = described_class.new Pkg.new('apr-util')
+      apr = described_class.new Pkg.new('apr')
+
+      php5.add_child apache2
+      apache2.add_child apr_util; apache2.add_child apr
+      apr_util.add_child apr
+
+      expect(php5.to_s).to eql('apr, apr-util, apache2')
+      expect(apache2.to_s).to eql('apr, apr-util')
+      expect(apr_util.to_s).to eql('apr')
+      expect(apr.to_s).to eql('')
     end
   end
 end


### PR DESCRIPTION
Prints a package's dependencies and tips.

Useful for finding out things like paths to config files or server document root.
