### PR TITLE
Added MySQL/Postgres PDO support to PHP

### DIFF
--- a/lib/autoparts/packages/php5.rb
+++ b/lib/autoparts/packages/php5.rb
@@ -31,8 +31,11 @@ module Autoparts
             # features
             "--enable-opcache",
             "--with-mysql",
+            "--with-pdo-mysql",                                                                                                                                                                                                                                                   
+            "--with-mysql-sock=/tmp/mysql.sock",
             "--with-openssl",
             "--with-pgsql",
+            "--with-pdo-pgsql",
             "--with-readline",
           ]
           execute './configure', *args


### PR DESCRIPTION
I've added PDO support for MySQL and PostgreSQL for PHP by adding the appropriate configure options. This will be useful for anyone who wishes to use the PDO extension.
