### PR TITLE
Add InfluxDB

### DIFF
--- a/lib/autoparts/packages/influxdb.rb
+++ b/lib/autoparts/packages/influxdb.rb
@@ -5,9 +5,11 @@ module Autoparts
       version '0.4.4'
       description 'InfluxDB: An open-source distributed time series database'
       source_url 'http://s3.amazonaws.com/influxdb/influxdb-0.4.4.src.tar.gz'
-      source_sha1 '4ba016ed09fa66c80974eea18a4c5036e2c10817'
+      source_sha1 '04d3b0c6f449daba9470791cc7dd58d88f07db6b'
       source_filetype 'tar.gz'
 
+      depends_on  'protobuf'
+      
       def install
         Dir.chdir('influxdb') do
           execute 'make', 'install'

--- a/lib/autoparts/packages/protobuf.rb
+++ b/lib/autoparts/packages/protobuf.rb
@@ -1,0 +1,26 @@
+module Autoparts
+  module Packages
+    class Protobuf < Package
+      name 'protobuf'
+      version '2.5.0'
+      description 'Protocol Buffers: language- and platform-neutral mechanism for serializing structured data'
+      source_url 'https://protobuf.googlecode.com/files/protobuf-2.5.0.tar.bz2'
+      source_sha1 '62c10dcdac4b69cc8c6bb19f73db40c264cb2726'
+      source_filetype 'tar.bz2'
+
+      def install
+        Dir.chdir('protobuf-2.5.0') do
+          execute 'make', 'install'
+        end
+      end
+
+      def compile
+        Dir.chdir('protobuf-2.5.0') do
+          args = ["--prefix=#{prefix_path}"]
+          execute './configure', *args
+          execute 'make'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Please kindly add InfluxDB to the list of software installable on Nitrous.IO. It's a new kid on the block but it is pretty unique in what it does AND has no external dependencies so it fits the bill pretty nicely.
