### PR TITLE
Compile PHP with --with-curl

### DIFF
--- a/lib/autoparts/packages/php5.rb
+++ b/lib/autoparts/packages/php5.rb
@@ -39,6 +39,7 @@ module Autoparts
             "--with-readline",
             "--with-gd",
             "--with-jpeg",
+            "--with-curl",
             "--enable-zip"
           ]
           execute './configure', *args


### PR DESCRIPTION
PHP CURL library is needed in order to call APIs
