### PR TITLE
Added bcmath support for Appengine

### DIFF
--- a/lib/autoparts/packages/php5.rb
+++ b/lib/autoparts/packages/php5.rb
@@ -44,7 +44,8 @@ module Autoparts
             "--with-zlib",
             "--with-iconv",
             "--enable-mbstring",
-            "--enable-soap"
+            "--enable-soap",
+            "--enable-bcmath"
           ]
           execute './configure', *args
           execute 'make'


### PR DESCRIPTION
Appengine requires bccomp to function.

_PHPEnvironmentError: The PHP runtime requires the "bccomp" function, which is not defined.  
If you built PHP using "configure" then please rebuild with:  
 ./configure  --enable-bcmath
