### PR TITLE
Add mysqli extension to PHP

### DIFF
--- a/lib/autoparts/packages/php5.rb
+++ b/lib/autoparts/packages/php5.rb
@@ -31,6 +31,7 @@ module Autoparts
             # features
             "--enable-opcache",
             "--with-mysql",
+            "--with-mysqli",
             "--with-pdo-mysql",
             "--with-mysql-sock=/tmp/mysql.sock",
             "--with-openssl",


### PR DESCRIPTION
I've added the mysqli extension to PHP by adding the appropriate configure option. 
