### PR TITLE
limit number of httpd workers

### DIFF
--- a/lib/autoparts/packages/apache2.rb
+++ b/lib/autoparts/packages/apache2.rb
@@ -171,6 +171,10 @@ module Autoparts
           ServerName 127.0.0.1
           Listen 0.0.0.0:3000
           ServerLimit 1
+          MinSpareThreads 1
+          MaxSpareThreads 10
+          ThreadsPerChild 10
+          MaxRequestsPerChild 100
           MaxRequestWorkers 10
           ListenBackLog 1024
 


### PR DESCRIPTION
Reduce memory usage of httpd server so it works better with low-memory box
- limit number of apache process to 1
- lower MaxRequestWorkers
