### PR TITLE
Replace s3 buckets and binary host when we want to get packages from/to staging buckets

### DIFF
--- a/lib/autoparts/package.rb
+++ b/lib/autoparts/package.rb
@@ -97,6 +97,14 @@ module Autoparts
       ENV['AUTOPARTS_HOST'] || BINARY_HOST
     end
 
+    # if we found AUTOPARTS_BUCKET variable, use that as the bucket host,
+    # otherwise use the default production value.
+    #
+    # This is useful when we want to upload a package to staging bucket.
+    def binary_bucket
+      ENV['AUTOPARTS_BUCKET'] || BINARY_BUCKET
+    end
+
     def initialize
       @source_install = false
     end
@@ -381,7 +389,7 @@ module Autoparts
         puts "=> Uploading #{name} #{version}..."
         [binary_file_name, binary_sha1_file_name].each do |f|
           local_path = Path.archives + f
-          `s3cmd put --acl-public --guess-mime-type #{local_path} s3://#{BINARY_BUCKET}/#{f}`
+          `s3cmd put --acl-public --guess-mime-type #{local_path} s3://#{binary_bucket}/#{f}`
         end
         puts "=> Done"
       else


### PR DESCRIPTION
This allows us to set a staging environment for Autoparts packages where auto-compiled packages can be tested before we make it available to production.
