### PR TITLE
Initial GHC 7.6.3 package

### DIFF
--- a/lib/autoparts/packages/ghc.rb
+++ b/lib/autoparts/packages/ghc.rb
@@ -1,0 +1,32 @@
+module Autoparts
+  module Packages
+    class Ghc < Package
+      name 'ghc'
+      version '7.6.3'
+      description 'GHC'
+      source_url 'http://www.haskell.org/ghc/dist/7.6.3/ghc-7.6.3-x86_64-unknown-linux.tar.bz2'
+      source_sha1 '46ec3f3352ff57fba0dcbc8d9c20f7bcb6924b77'
+      source_filetype 'tar.bz2'
+      
+      def compile
+        Dir.chdir('ghc-7.6.3') do
+          
+          # Very annoying having to do workarounds for libgmp.  This will be fixed in GHC 7.8 apparently, 
+          # but this is an artifact of GHC's build system being based on the outdated debian system, 
+          # which had an older version of libgmp, and had that version number overspecified.
+          execute "mkdir -p #{lib_path}"
+          execute "ln -sf /usr/lib/x86_64-linux-gnu/libgmp.so.10.0.2 #{lib_path}/libgmp.so.3"
+          execute "ln -sf /usr/lib/x86_64-linux-gnu/libgmp.so.10.0.2 #{lib_path}/libgmp.so"
+
+          args = [
+            "--prefix=#{prefix_path}"
+          ]
+          
+          execute "ls -alh > ~/debug.txt"
+          execute "LD_LIBRARY_PATH=#{lib_path} ./configure #{args.join(' ')}"
+          execute "LD_LIBRARY_PATH=#{lib_path} make install"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This installs GHC successfully on its own, but lacks the rest of the haskell ecosystem (ie, Cabal as a package manager).

I don't see any way to make multiple distinct packages get installed as a single install, so I imagine that you'll have to run a few commands in a row to get a full environment. It'll be:

```
parts install ghc
parts install cabal
```

The other gotcha is that it requires more ram & disk space than the free level allows. I don't see much of a way around that unfortunately.

Next up is cabal... 
