### PR TITLE
Initial version of cabal-install (1.18.1.2)

### DIFF
--- a/lib/autoparts/packages/cabal_install.rb
+++ b/lib/autoparts/packages/cabal_install.rb
@@ -7,6 +7,8 @@ module Autoparts
       source_url 'http://www.haskell.org/cabal/release/cabal-install-1.18.0.2/cabal-install-1.18.0.2.tar.gz'
       source_sha1 '2d1f7a48d17b1e02a1e67584a889b2ff4176a773'
       source_filetype 'tar.gz'
+
+      depends_on 'ghc'
       
       def compile
         Dir.chdir('cabal-install-1.18.0.2') do


### PR DESCRIPTION
Relies on my GHC pull request (#72). If you install both, you end up with a haskell environment to use.
