### PR TITLE
Limit Apache workers and memory leaks

### DIFF
--- a/lib/autoparts/packages/apache2.rb
+++ b/lib/autoparts/packages/apache2.rb
@@ -209,26 +209,26 @@ module Autoparts
 
           DocumentRoot "#{htdocs_path}"
           <Directory "#{htdocs_path}">
-              Options Indexes FollowSymLinks
-              AllowOverride All
-              Require all granted
+            Options Indexes FollowSymLinks
+            AllowOverride All
+            Require all granted
           </Directory>
 
           <IfModule dir_module>
-              DirectoryIndex index.html
+            DirectoryIndex index.html
           </IfModule>
 
           <Files ".ht*">
-              Require all denied
+            Require all denied
           </Files>
 
           ErrorLog "#{Path.var + name + "log" + "error_log"}"
           LogLevel warn
 
           <IfModule mime_module>
-              TypesConfig #{mime_types_path}
-              AddType application/x-compress .Z
-              AddType application/x-gzip .gz .tgz
+            TypesConfig #{mime_types_path}
+            AddType application/x-compress .Z
+            AddType application/x-gzip .gz .tgz
           </IfModule>
 
           <IfModule ssl_module>
@@ -237,14 +237,15 @@ module Autoparts
           </IfModule>
 
           <IfModule mpm_event_module>
-              StartServers          1
-              ServerLimit           2
-              MinSpareThreads      15
-              MaxSpareThreads      25
-              ThreadLimit          25
-              ThreadsPerChild      25
-              MaxClients           50
-              MaxRequestsPerChild  88
+            StartServers              1
+            ServerLimit               1
+            MinSpareThreads           5
+            MaxSpareThreads           5
+            ThreadLimit               5
+            ThreadsPerChild           5
+            MaxRequestWorkers         5
+            MaxConnectionsPerChild   50
+            ListenBackLog          1024
           </IfModule>
         EOS
       end


### PR DESCRIPTION
Supercedes #65
- limits number of apache process
- serve at most 50 requests, after which child process dies (reduces accidental memory leaks).
