### PR TITLE
phpMyAdmin was previously installing with the folder

### DIFF
--- a/lib/autoparts/packages/phpmyadmin.rb
+++ b/lib/autoparts/packages/phpmyadmin.rb
@@ -21,7 +21,7 @@ module Autoparts
         phpmyadmin_path.parent.mkpath
         FileUtils.rm_rf phpmyadmin_path
         FileUtils.mkdir_p prefix_path
-        FileUtils.cp_r extracted_archive_path + 'phpMyAdmin-4.1.7-all-languages/.', extracted_archive_path
+        execute 'mv', extracted_archive_path + 'phpMyAdmin-4.1.7-all-languages/', phpmyadmin_path
         execute 'rm', '-rf', "#{extracted_archive_path}/phpMyAdmin-4.1.7-all-languages"
         execute 'mv', extracted_archive_path, phpmyadmin_path
         execute 'cp', phpmyadmin_path + phpmyadmin_sample_config, prefix_path


### PR DESCRIPTION
phpMyAdmin-4.1.7-all-languages/ nested within workspace/www/phpMyAdmin ,
and assumed it was not there. This was breaking the install. This commit
moves the content back one directory for proper installation.
