### PR TITLE
Enable mysql native driver compile options, enabling mysqli

### DIFF
--- a/lib/autoparts/packages/php5.rb
+++ b/lib/autoparts/packages/php5.rb
@@ -35,9 +35,9 @@ module Autoparts
             "--docdir=#{doc_path}",
             # features
             "--enable-opcache",
-            "--with-mysql",
-            "--with-mysqli",
-            "--with-pdo-mysql",
+            "--with-mysql=mysqlnd",
+            "--with-mysqli=mysqlnd",
+            "--with-pdo-mysql=mysqlnd",
             "--with-mysql-sock=/tmp/mysql.sock",
             "--with-openssl",
             "--with-pgsql",


### PR DESCRIPTION
From: 
http://www.php.net/manual/en/mysqlnd.install.php
http://www.php.net/manual/en/mysqli.installation.php

I think this is pretty safe:
http://www.php.net/manual/en/mysqlnd.incompatibilities.php

But of course, need a better pair of :eyes: 
