### PR TITLE
Eval output of `parts env` instead of `parts init`

### DIFF
--- a/lib/autoparts/commands/init.rb
+++ b/lib/autoparts/commands/init.rb
@@ -43,7 +43,7 @@ module Autoparts
           # Load environment variables for Autoparts automatically by
           # adding the following to #{profile}
 
-          eval "$(parts init -)"
+          eval "$(parts env)"
         STR
       end
 

--- a/script/setup_buildenv
+++ b/script/setup_buildenv
@@ -49,5 +49,5 @@ urlencoding_mode = normal
 use_https = False
 verbosity = WARNING" > /home/action/.s3cfg
 
-eval "$(parts init -)"
+eval "$(parts env)"
 exec /bin/bash

--- a/setup.rb
+++ b/setup.rb
@@ -26,7 +26,7 @@ def inject_parts_init(path)
   file = File.read(path)
   File.open(path, 'a') do |f|
     export_path = "export PATH=\"$HOME/#{relative_autoparts_bin_path}:$PATH\"\n"
-    parts_init = "eval \"$(parts init -)\"\n"
+    parts_init = "eval \"$(parts env)\"\n"
     f.write "\n"
     f.write export_path unless file.include? export_path
     f.write parts_init unless file.include? parts_init


### PR DESCRIPTION
Because `parts init` also auto-starts services, which we do not want.

Those services will probably print some output as well, and we'll inadvertently eval that ಠ_ಠ.
