### PR TITLE
Do not start packages on `parts init -`, only if --start option given

### DIFF
--- a/lib/autoparts/commands/init.rb
+++ b/lib/autoparts/commands/init.rb
@@ -9,6 +9,8 @@ module Autoparts
     class Init
       def initialize(args, options)
         if options.first == '-'
+          # NOTE: a common usage of parts init is `eval $(parts init -)`.
+          # Ensure that everything run below does not have stray output
           no_autoupdate_env = ENV['AUTOPARTS_NO_AUTOUPDATE']
           if autoupdate_due? && !(no_autoupdate_env && ['1', 'true'].include?(no_autoupdate_env.downcase))
             if Update.update(true)
@@ -23,8 +25,9 @@ module Autoparts
               end
             end
           end
-          Autoparts::Package.start_all
           Env.print_exports
+        elsif options.include? '--start'
+          Autoparts::Package.start_all
         else
           show_help
         end

--- a/spec/commands/init_spec.rb
+++ b/spec/commands/init_spec.rb
@@ -13,6 +13,21 @@ describe Autoparts::Commands::Init do
     described_class.new [], []
   end
 
+  describe 'when run with - option' do
+    it 'does not attempt starting all packages' do
+      expect(Autoparts::Package).not_to receive :start_all
+      described_class.any_instance.stub(:autoupdate_due?).and_return false
+      described_class.new([], ['-'])
+    end
+  end
+
+  describe 'when run with --start option' do
+    it 'starts all packages' do
+      expect(Autoparts::Package).to receive :start_all
+      described_class.new([], ['--start'])
+    end
+  end
+
   describe '#autoupdate_due?' do
     context 'when update has never been performed before' do
       it 'returns true' do


### PR DESCRIPTION
The command `eval $(parts init -)` was previously encouraged and
used in docs, causing stray output from packages starting to be
evaluated.  We now require an explicit --start option to run
package starts.
