### PR TITLE
Updates Google App Engine SDKs to 1.9.5

### DIFF
--- a/lib/autoparts/packages/googleappengine.rb
+++ b/lib/autoparts/packages/googleappengine.rb
@@ -5,12 +5,12 @@ module Autoparts
   module Packages
     class GoogleAppEngine < Package
       name 'googleappengine'
-      version '1.9.4'
+      version '1.9.5'
       description 'Google App Engine Python/PHP: A CLI for managing Google App Engine cloud services for Python and PHP'
       category Category::DEPLOYMENT
 
-      source_url 'https://commondatastorage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.4.zip'
-      source_sha1 'ee44f7bcc16b4d72c3af0a4f744048d44f75c5ce'
+      source_url 'https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.5.zip'
+      source_sha1 '070ba616fbeecff4bf6c5f43c00a43c21fbb108e'
       source_filetype 'zip'
 
       def install

--- a/lib/autoparts/packages/googleappenginego.rb
+++ b/lib/autoparts/packages/googleappenginego.rb
@@ -2,12 +2,12 @@ module Autoparts
   module Packages
     class GoogleAppEngineGo < Package
       name 'googleappenginego'
-      version '1.9.4'
+      version '1.9.5'
       description 'Google App Engine Go: A CLI for managing Google App Engine cloud services for Go'
       category Category::DEPLOYMENT
 
-      source_url 'https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.4.zip'
-      source_sha1 'ff7c6565d04c99c40fa8fddd0cc8f3ab2e86ba4e'
+      source_url 'https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.5.zip'
+      source_sha1 'cba2407efffd9540d5f3c56460f6958bd5647f68'
       source_filetype 'zip'
 
       def install


### PR DESCRIPTION
Updates Google App Engine SDKs for Python/PHP and Go
to version 1.9.5
