### PR TITLE
Added Google App Engine Java part.

### DIFF
--- a/lib/autoparts/packages/googleappenginejava.rb
+++ b/lib/autoparts/packages/googleappenginejava.rb
@@ -13,7 +13,7 @@ module Autoparts
       def install
         prefix_path.parent.mkpath
         FileUtils.rm_rf prefix_path
-        execute 'mv', extracted_archive_path + 'appengine-java-sdk-1.9.5', prefix_path
+        execute 'mv', extracted_archive_path + "appengine-java-sdk-#{version}", prefix_path
       end
 
       def post_install


### PR DESCRIPTION
Includes the Google App Engine Java SDK autopart,
to allow Java developers to write, test and deploy
Java apps to Google App Engine.

This part is based on the Google App Engine part.
