### PR TITLE
Google Cloud SDK

### DIFF
--- a/lib/autoparts/packages/googlecloudsdk.rb
+++ b/lib/autoparts/packages/googlecloudsdk.rb
@@ -3,7 +3,7 @@ module Autoparts
     class GoogleCloudSDK < Package
       name 'googlecloudsdk'
       version '0.9.25'
-      description 'Google Cloud SDK: tools and libraries that enable you to easily create and manage resources on Google Cloud Platform'
+      description 'Google Cloud SDK: Tools and libraries to easily create and manage resources on Google Cloud Platform'
       category Category::UTILITIES
 
       source_url 'https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz'
@@ -20,37 +20,39 @@ module Autoparts
           '--path-update=false',
           '--disable-installation-options',
           '--rc-path=/tmp/.bashrc'
-        ]
+          ]
         execute "#{prefix_path}/install.sh", *args 
       end
+      
+      def symlink_all
+        # Avoid linking as we added the tools to PATH
+      end
 
-      def post_install
-        bin_path.mkpath
-        ['bq', 'gcloud', 'gcutil', 'gsutil'].each do |p|
-          execute 'ln', '-s', prefix_path + p, Path.bin + p
-        end
+      def required_env
+        # We put the bin folder from Google Cloud SDK into PATH
+        # so new components installed can work properly.
+        [
+          "export PATH=$PATH:#{prefix_path}/bin"
+        ]
       end
 
       def tips
         <<-EOS.unindent
-          Autoparts has installed the Google Cloud SDK and added this tools to
-          your path: gcloud, bq, gcutil, gsutil
+          Autoparts has installed the Google Cloud SDK and added it's
+          binaries in your PATH environment variable.
+          You can restart your shell to use the tools: gcloud, bq,
+          gcutil and gsutil.
 
-          To get started, first authenticate with:
+          To get started, first authenticate your box with:
 
             gcloud auth login
 
-          You can update, add and remove components using gcloud:
+          You can update, add and remove components using gcloud command:
 
             gcloud components update        # Update all components
             gcloud components update pkg-go # Install the Go SDK
 
-          For more information about other options:
-
-            gcloud help
-            bq help
-            gsutil help
-            gcutil help
+          All tools accept a 'help' command that display usage tips.
         EOS
       end
     end


### PR DESCRIPTION
The Google Cloud SDK is the new toolset from Google,
that allows developers to have a central tool to manage
all Google Cloud Platform Resources, including App Engine,
Compute Engine, Bigquery, Cloud Storage and others.

This PR makes the bin folder from the SDK available, so
more components installed will be available for users.

The caveat is that there is no "stable" version download URL.
If the current package contents change, the SHA1 sum must
be updated.
