### PR TITLE
Added PostgreSQL 9.3 to Autoparts

### DIFF
--- a/lib/autoparts/packages/postgresql.rb
+++ b/lib/autoparts/packages/postgresql.rb
@@ -14,7 +14,7 @@ module Autoparts
       source_filetype 'tar.gz'
 
       def compile
-        Dir.chdir('postgresql-9.2.4') do
+        Dir.chdir(archive_dir) do
           args = [
             '--disable-debug',
             "--prefix=#{prefix_path}",
@@ -40,9 +40,13 @@ module Autoparts
       end
 
       def install
-        Dir.chdir('postgresql-9.2.4') do
+        Dir.chdir(archive_dir) do
           execute 'make install-world'
         end
+      end
+
+      def archive_dir
+        'postgresql-9.2.4'
       end
 
       def post_install
@@ -75,16 +79,20 @@ module Autoparts
       end
 
       def purge
+        if postgres_var_path.exist?
+          postgres_conf = postgres_var_path + 'postgresql.conf'
+          FileUtils.rm_rf postgres_conf
+        end
         postgres_var_path.rmtree if postgres_var_path.exist?
         postgres_log_path.rmtree if postgres_log_path.exist?
       end
 
       def postgres_var_path
-        Path.var + 'postgresql'
+        Path.var + "#{name}"
       end
 
       def postgres_log_path
-        Path.var + 'log' + 'postgresql'
+        Path.var + 'log' + "#{name}"
       end
 
       def pg_ctl_path

--- a/lib/autoparts/packages/postgresql9.3.rb
+++ b/lib/autoparts/packages/postgresql9.3.rb
@@ -1,0 +1,23 @@
+# Copyright (c) 2013-2014 Irrational Industries Inc. d.b.a. Nitrous.IO
+# This software is licensed under the [BSD 2-Clause license](https://raw.github.com/nitrous-io/autoparts/master/LICENSE).
+
+require File.join(File.dirname(__FILE__), 'postgresql')
+
+module Autoparts
+  module Packages
+    class PostgreSQL93 < PostgreSQL
+      name 'postgresql9.3'
+      version '9.3.4'
+      description "PostgreSQL: The world's most advanced open-source database system"
+      category Category::DATA_STORES
+
+      source_url 'http://ftp.postgresql.org/pub/source/v9.3.4/postgresql-9.3.4.tar.gz'
+      source_sha1 '9f80b3cfebc434ca0860fc8489923cea73456081'
+      source_filetype 'tar.gz'
+
+      def archive_dir
+        'postgresql-9.3.4'
+      end
+    end
+  end
+end


### PR DESCRIPTION
When dealing with both versions, the last package which is installed is what will take precedence. I've tested both versions and works.
- New package pulls in install methods from PostgreSQL package.
- Modified package to remove /home/action/.parts/var/postgresql/postgresql.conf upon purge.

Before merging we will need to update support docs and also create binaries. I can do this once this once given the "okay" to merge.
