### PR TITLE
Check for updates when starting a new shell.

### DIFF
--- a/lib/autoparts/commands/init.rb
+++ b/lib/autoparts/commands/init.rb
@@ -46,7 +46,7 @@ module Autoparts
           # Load environment variables for Autoparts automatically by
           # adding the following to #{profile}
 
-          eval "$(parts env)"
+          eval "$(parts init -)"
         STR
       end
 

--- a/script/setup_buildenv
+++ b/script/setup_buildenv
@@ -47,5 +47,5 @@ urlencoding_mode = normal
 use_https = False
 verbosity = WARNING" > /home/action/.s3cfg
 
-eval "$(parts env)"
+eval "$(parts init -)"
 exec /bin/bash

--- a/setup.rb
+++ b/setup.rb
@@ -26,7 +26,7 @@ def inject_parts_init(path)
   file = File.read(path)
   File.open(path, 'a') do |f|
     export_path = "export PATH=\"$HOME/#{relative_autoparts_bin_path}:$PATH\"\n"
-    parts_init = "eval \"$(parts env)\"\n"
+    parts_init = "eval \"$(parts init -)\"\n"
     f.write "\n"
     f.write export_path unless file.include? export_path
     f.write parts_init unless file.include? parts_init


### PR DESCRIPTION
This reinstates the original behaviour of checking for updates (which is included in `parts init`) when starting a new shell.
