### PR TITLE
Update CLI to 2.6.3, and include the deployment tool

### DIFF
--- a/lib/autoparts/packages/elasticbeanstalk.rb
+++ b/lib/autoparts/packages/elasticbeanstalk.rb
@@ -5,12 +5,12 @@ module Autoparts
   module Packages
     class Elasticbeanstalk < Package
       name 'elasticbeanstalk'
-      version '2.6.2'
+      version '2.6.3'
       description "Elastic Beanstalk Command Line Tool: A command line client for interacting with the AWS Elastic Beanstalk APIs"
       category Category::UTILITIES
 
-      source_url 'https://s3.amazonaws.com/elasticbeanstalk/cli/AWS-ElasticBeanstalk-CLI-2.6.2.zip'
-      source_sha1 '35e91aed51cc3d39cffe5e557de05d403f30edfc'
+      source_url 'https://s3.amazonaws.com/elasticbeanstalk/cli/AWS-ElasticBeanstalk-CLI-2.6.3.zip'
+      source_sha1 'c510df910b657d98ab7b86497a3f61f7616f935e'
       source_filetype 'zip'
 
       depends_on 'python2'
@@ -18,7 +18,21 @@ module Autoparts
       def install
         prefix_path.parent.mkpath
         FileUtils.rm_rf prefix_path
-        execute 'mv', extracted_archive_path + 'AWS-ElasticBeanstalk-CLI-2.6.2/eb/linux/python2.7', prefix_path
+        execute 'mv', extracted_archive_path + 'AWS-ElasticBeanstalk-CLI-2.6.3/eb/linux/python2.7', prefix_path
+        execute 'mv', extracted_archive_path + 'AWS-ElasticBeanstalk-CLI-2.6.3/AWSDevTools/Linux/AWSDevTools-RepositorySetup.sh', prefix_path
+        execute 'mv', extracted_archive_path + 'AWS-ElasticBeanstalk-CLI-2.6.3/AWSDevTools/Linux/scripts', prefix_path
+      end
+
+      def symlink_all
+        symlink_recursively(prefix_path, Path.bin, only_executables: true)
+      end
+
+      def tips
+        <<-EOS.unindent
+          For each Git repository you will need to run AWSDevTools-RepositorySetup.sh:
+
+          $ AWSDevTools-RepositorySetup.sh
+        EOS
       end
 
       def symlink_all


### PR DESCRIPTION
- Install includes AWS-ElasticBeanstalk-CLI-2.6.3/AWSDevTools/Linux/AWSDevTools-RepositorySetup.sh
- Install includes AWS-ElasticBeanstalk-CLI-2.6.3/AWSDevTools/Linux/scripts
