### PR TITLE
Add Ghost package

### DIFF
--- a/lib/autoparts/packages/ghost.rb
+++ b/lib/autoparts/packages/ghost.rb
@@ -45,7 +45,17 @@ module Autoparts
           execute 'npm start'
         end
       end
+
+      def stop
+        Dir.chdir(ghost_path) do
+          execute 'npm stop'
+        end
+      end
       
+      def running?
+        !!system(ghost_path.to_s, 'status', out: '/dev/null', err: '/dev/null')       
+      end
+
       def tips
         <<-EOS.unindent
           You're ready to blog with Ghost!
@@ -56,7 +66,8 @@ module Autoparts
           To terminate your Ghost instance, use Ctrl+C inside your terminal.
 
           By default, Ghost runs on port 4000 and is bound to all interfaces (0.0.0.0).
-          These settings can be changed inside your config.js. 
+          These settings can be changed inside the "config.js" file located inside your Ghost root,
+          located at ~/.parts/packages/ghost/0.5.2/ by default. 
 
           If this is your first time using ghost, go to "http://your-preview-address.com:4000/ghost"
           to get your account set up. 


### PR DESCRIPTION
[Ghost](https://ghost.org) is a popular lightweight blogging platform. 

Having a Ghost package on Nitrous will let users throw up a lightweight blog for testing themes or extensions. Many Ghost users employ active Ghost installations locally and then build static pages and deploy these to services like Github Pages. The Ghost package will facilitate this use of a Nitrous box as well. 

This installation follows Ghost's [currently recommended method](http://support.ghost.org/installing-ghost-linux/) and relies on the most recent stable version, v0.5.2. 

This package file works great from the terminal and changes Ghost's default routing options to work with Nitrous's preview function in `post_install`. However, the installation's dependencies rely on "npm install", which fails without explanation when trying to run from the Autoparts GUI. This issue was mentioned on [PR #114] but ultimately wasn't resolved. 

Short of writing out a Makefile to manually grab all the dependencies, any tips to finalize this Part?
