### PR TITLE
Update Node.js from v0.10.31 to v0.10.32

### DIFF
--- a/lib/autoparts/packages/nodejs.rb
+++ b/lib/autoparts/packages/nodejs.rb
@@ -5,12 +5,12 @@ module Autoparts
   module Packages
     class Nodejs < Package
       name 'nodejs'
-      version '0.10.31'
+      version '0.10.32'
       description "Node.JS: A platform built on Chrome's JavaScript runtime for easily building fast, scalable network applications"
       category Category::PROGRAMMING_LANGUAGES
 
-      source_url 'http://nodejs.org/dist/v0.10.31/node-v0.10.31-linux-x64.tar.gz'
-      source_sha1 '0a47909aff7d52759972b0de915b624ede092ae2'
+      source_url 'http://nodejs.org/dist/v0.10.32/node-v0.10.32-linux-x64.tar.gz'
+      source_sha1 'fadefc15a992d21bd19d0d3ec174390d1e7fcb72'
       source_filetype 'tar.gz'
 
       def install


### PR DESCRIPTION
Node.js v0.10.31 is suffering a segmentation fault bug in Node Core, so I suggest upgrading to the latest stable version v0.10.32 to get rid of those bugs.

File and SHA1 are taken directly from http://nodejs.org/dist/v0.10.32/
