### PR TITLE
Portuguese translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ View [contributing.md](https://github.com/nitrous-io/autoparts/tree/master/docs/
 ### Additional Languages
 
 [日本語](https://github.com/action-io/autoparts/blob/master/README.ja.md)
-[Brazilian Portuguese](https://github.com/action-io/autoparts/blob/master/README.pt_br.md)
+
+[Português (Brasil)](https://github.com/action-io/autoparts/blob/master/README.pt_br.md)
 
 - - -
 Copyright (c) 2013-2014 Irrational Industries Inc. d.b.a. Nitrous.IO

--- a/README.pt_br.md
+++ b/README.pt_br.md
@@ -57,8 +57,8 @@ Veja [contributing.md](https://github.com/nitrous-io/autoparts/tree/master/docs/
 ### Línguas Adicionais
 
 [English](https://github.com/action-io/autoparts/blob/master/README.md)
+
 [日本語](https://github.com/action-io/autoparts/blob/master/README.ja.md)
-[Brazilian Portuguse](https://github.com/action-io/autoparts/blob/master/README.pt_br.md)
 
 - - -
 Copyright (c) 2013-2014 Irrational Industries Inc. d.b.a. Nitrous.IO


### PR DESCRIPTION
Translate the README.md to Brazilian Portuguese, and also modify the original README.md to contain the reference to the new README.pt_br.md file.
