### PR TITLE
Update mongodb from 2.4.9 to 2.6.5

### DIFF
--- a/lib/autoparts/packages/mongodb.rb
+++ b/lib/autoparts/packages/mongodb.rb
@@ -5,12 +5,12 @@ module Autoparts
   module Packages
     class MongoDB < Package
       name 'mongodb'
-      version '2.4.9'
+      version '2.6.5'
       description 'MongoDB: A cross-platform document-oriented NoSQL database system'
       category Category::DATA_STORES
 
-      source_url 'http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-2.4.9.tgz'
-      source_sha1 'ecb95cc0b791823d35166aab18ec4052ea781337'
+      source_url 'http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-2.6.5.tgz'
+      source_sha1 'd8d793fdd23b784e6d40c3e8e923926ac004a96d'
       source_filetype 'tar.gz'
 
       def compile


### PR DESCRIPTION
Update mongodb from 2.4.9 to 2.6.5 - Tested on a Nitrous box.
